### PR TITLE
feat: Implement password reset functionality with OTP verification

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/OtpController.php
+++ b/app/Http/Controllers/Api/V1/Auth/OtpController.php
@@ -174,13 +174,30 @@ class OtpController extends Controller
         // Clear rate limiting on successful verification
         RateLimiter::clear($key);
 
+        $responseData = [
+            'email' => $request->email,
+            'type' => $request->type,
+        ];
+
+        // If forgot password, generate and return a reset token
+        if ($request->type === 'forgot_password') {
+            $token = \Illuminate\Support\Str::random(60);
+            
+            \Illuminate\Support\Facades\DB::table('password_reset_tokens')->updateOrInsert(
+                ['email' => $request->email],
+                [
+                    'token' => \Illuminate\Support\Facades\Hash::make($token),
+                    'created_at' => now()
+                ]
+            );
+
+            $responseData['token'] = $token;
+        }
+
         return response()->json([
             'success' => true,
             'message' => 'OTP verified successfully',
-            'data' => [
-                'email' => $request->email,
-                'type' => $request->type,
-            ]
+            'data' => $responseData
         ]);
     }
 

--- a/app/Http/Controllers/Api/V1/Auth/PasswordResetController.php
+++ b/app/Http/Controllers/Api/V1/Auth/PasswordResetController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Auth\ResetPasswordRequest;
+use App\Models\Otp;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class PasswordResetController extends Controller
+{
+    /**
+     * Reset password using verified OTP
+     */
+    public function reset(ResetPasswordRequest $request): JsonResponse
+    {
+        // Check if the token exists in password_reset_tokens
+        $record = DB::table('password_reset_tokens')
+            ->where('email', $request->email)
+            ->first();
+
+        if (!$record || !Hash::check($request->token, $record->token)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Invalid or expired reset token.',
+            ], 400);
+        }
+        
+        // Check token expiration (e.g., 60 minutes)
+        if (now()->diffInMinutes($record->created_at) > 60) {
+             DB::table('password_reset_tokens')->where('email', $request->email)->delete();
+             return response()->json([
+                'success' => false,
+                'message' => 'Reset token expired.',
+            ], 400);
+        }
+
+        // Update user password
+        $user = User::where('email', $request->email)->first();
+        
+        $user->forceFill([
+            'password' => Hash::make($request->password),
+        ])->save();
+        
+        // Delete the used token
+        DB::table('password_reset_tokens')->where('email', $request->email)->delete();
+
+        // Also clean up the OTPs
+        Otp::where('email', $request->email)
+            ->where('type', 'forgot_password')
+            ->delete();
+
+        // Revoke all tokens (Security)
+        $user->tokens()->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Password has been successfully reset.',
+        ]);
+    }
+}

--- a/app/Http/Requests/Api/V1/Auth/ResetPasswordRequest.php
+++ b/app/Http/Requests/Api/V1/Auth/ResetPasswordRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ResetPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => ['required'],
+            'email' => ['required', 'email', 'exists:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password_confirmation' => ['required'],
+        ];
+    }
+}

--- a/docs/CITIZEN_FORGOT_PASSWORD.md
+++ b/docs/CITIZEN_FORGOT_PASSWORD.md
@@ -1,0 +1,176 @@
+# Citizen Forgot Password API Integration Guide
+
+## Overview
+
+This document details the API endpoints and integration workflow for the Citizen Forgot Password feature. It is designed to guide frontend developers in implementing a secure and user-friendly password recovery process.
+
+## 🔄 Integration Workflow
+
+The password reset process consists of three distinct steps:
+
+1.  **Request OTP**: The user provides their registered email address, which is then sent via a POST request to initiate the OTP sending process. The system sends a One-Time Password (OTP) to that email.
+2.  **Verify OTP**: The user enters the received OTP. The system verifies it and, if valid, returns a temporary **reset token**.
+3.  **Reset Password**: The user provides a new password along with the **reset token**. The system updates the password and invalidates the token.
+
+---
+
+## 📡 API Reference
+
+### 1. Initiate Password Reset (Send OTP)
+
+Triggers the generation and dispatch of an OTP to the user's email address.
+
+-   **Endpoint:** `POST /api/v1/otp/send`
+-   **Access:** Public
+-   **Description:** specific `type` must be set to `"forgot_password"` to ensure the correct email template and logic are used.
+
+#### Request Body
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `email` | `string` | Yes | The registered email address of the user. |
+| `type` | `string` | Yes | Must be exactly `"forgot_password"`. |
+
+#### Example Request
+```json
+{
+  "email": "citizen@example.com",
+  "type": "forgot_password"
+}
+```
+
+#### Responses
+
+**200 OK** - OTP sent successfully
+```json
+{
+  "success": true,
+  "message": "OTP sent successfully to your email."
+}
+```
+
+**422 Unprocessable Entity** - Validation Error (e.g., email not found)
+```json
+{
+  "message": "The selected email is invalid.",
+  "errors": {
+    "email": ["The selected email is invalid."]
+  }
+}
+```
+
+---
+
+### 2. Verify OTP & Retrieve Token
+
+Verifies the OTP provided by the user. If successful, it returns a secure **reset token** required for the final step.
+
+-   **Endpoint:** `POST /api/v1/otp/verify`
+-   **Access:** Public
+-   **Description:** This step is critical. The frontend **must** capture the `token` from the response data to authorize the password reset request.
+
+#### Request Body
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `email` | `string` | Yes | The registered email address. |
+| `otp` | `string` | Yes | The 6-digit code received via email. |
+| `type` | `string` | Yes | Must be exactly `"forgot_password"`. |
+
+#### Example Request
+```json
+{
+  "email": "citizen@example.com",
+  "otp": "123456",
+  "type": "forgot_password"
+}
+```
+
+#### Responses
+
+**200 OK** - Verification Successful
+```json
+{
+  "success": true,
+  "message": "OTP verified successfully",
+  "data": {
+    "email": "citizen@example.com",
+    "type": "forgot_password",
+    "token": "7382a893-1b2c-4d5e-9f0a-secure_token_string"
+  }
+}
+```
+
+**400 Bad Request** - Invalid or Expired OTP
+```json
+{
+  "success": false,
+  "message": "Invalid or expired OTP."
+}
+```
+
+---
+
+### 3. Set New Password
+
+Finalizes the process by setting the new password. This requires the secure token obtained from the previous step.
+
+-   **Endpoint:** `POST /api/v1/password/reset`
+-   **Access:** Public
+-   **Description:** Resets the user's password. Existing authentication tokens for the user will be revoked for security.
+
+#### Request Body
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `email` | `string` | Yes | The user's email address. |
+| `token` | `string` | Yes | The secure token received from the `/otp/verify` endpoint. |
+| `password` | `string` | Yes | The new password (min. 8 characters). |
+| `password_confirmation` | `string` | Yes | Must match the `password` field. |
+
+#### Example Request
+```json
+{
+  "email": "citizen@example.com",
+  "token": "7382a893-1b2c-4d5e-9f0a-secure_token_string",
+  "password": "newSecurePassword123!",
+  "password_confirmation": "newSecurePassword123!"
+}
+```
+
+#### Responses
+
+**200 OK** - Password Reset Successful
+```json
+{
+  "success": true,
+  "message": "Password has been successfully reset."
+}
+```
+
+**400 Bad Request** - Invalid Token or Logic Error
+```json
+{
+  "success": false,
+  "message": "Invalid or expired reset token."
+}
+```
+
+**422 Unprocessable Entity** - Validation Error (e.g., passwords do not match)
+```json
+{
+  "message": "The password field confirmation does not match.",
+  "errors": {
+    "password": ["The password field confirmation does not match."]
+  }
+}
+```
+
+---
+
+## 🛑 Common Error Codes
+
+| Status Code | Meaning | Description |
+| :--- | :--- | :--- |
+| **200** | OK | Request processed successfully. |
+| **400** | Bad Request | Business logic failure (e.g., invalid OTP, expired token). |
+| **422** | Unprocessable Entity | Validation failure (e.g., invalid email format, weak password). |
+| **429** | Too Many Requests | Rate limit exceeded. Please implement exponential backoff. |
+| **500** | Internal Server Error | Server-side issue. |

--- a/routes/api/v1/auth.php
+++ b/routes/api/v1/auth.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\V1\Auth\AuthController;
 use App\Http\Controllers\Api\V1\Auth\OtpController;
+use App\Http\Controllers\Api\V1\Auth\PasswordResetController;
 use Illuminate\Support\Facades\Route;
 
 //========OTP Routes========//
@@ -13,6 +14,7 @@ Route::prefix('otp')->group(function () {
 });
 
 //========Auth Routes========//
+Route::post('/password/reset', [PasswordResetController::class, 'reset']);
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/login/purok-leader', [AuthController::class, 'loginPurokLeader']);


### PR DESCRIPTION
This pull request implements a secure "Forgot Password" workflow for citizens, introducing a new API endpoint and supporting logic for password resets via OTP verification. The changes cover backend controller logic, request validation, routing, and comprehensive documentation for frontend integration. The workflow now issues a reset token after OTP verification and uses it to authorize password resets, improving both security and usability.

**Forgot Password Workflow Implementation**

* Added `PasswordResetController` with a `reset` method to handle password resets using a secure token, including token validation, expiration checks, password update, and token/OTP cleanup.
* Updated `OtpController` to generate and return a reset token after successful OTP verification for "forgot_password" requests, storing the token securely and sending it in the response.
* Added `ResetPasswordRequest` for validating the password reset request, ensuring required fields, email existence, and password confirmation.

**Routing**

* Registered the new password reset endpoint (`POST /api/v1/password/reset`) in the API routes, enabling public access to the workflow. [[1]](diffhunk://#diff-25b77f6ed40f6d3e5b722079fae25e8d1f8e51922d462591b1d3346f38c01cc4R5) [[2]](diffhunk://#diff-25b77f6ed40f6d3e5b722079fae25e8d1f8e51922d462591b1d3346f38c01cc4R17)

**Documentation**

* Added `CITIZEN_FORGOT_PASSWORD.md` with a step-by-step guide for frontend developers, detailing endpoints, request/response formats, and error handling for the new workflow.